### PR TITLE
Docker container and port change

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM alpine:3.5
+
+MAINTAINER brunopsoares
+
+RUN apk --no-cache add \
+      curl \
+      python \
+      py-pip \
+    && pip install prometheus-couchbase-exporter \
+    && rm -rf /var/cache/apk/*
+
+# runtime environment variables
+ENV COUCHBASE_HOST="127.0.0.1" \
+    COUCHBASE_PORT="8091" \
+    COUCHBASE_USERNAME="" \
+    COUCHBASE_PASSWORD="" \
+    PROMETHEUS_PORT="9420"
+
+COPY ./docker-entrypoint.sh /docker-entrypoint.sh
+
+ENTRYPOINT ["/docker-entrypoint.sh"]
+
+CMD prometheus-couchbase-exporter -c http://${COUCHBASE_HOST}:${COUCHBASE_PORT} -p ${PROMETHEUS_PORT}

--- a/README.rst
+++ b/README.rst
@@ -20,9 +20,33 @@ Install via ``pip``:
 Usage example:
 --------------
 
-By default, it will bind to port 9119, query Couchbase on 127.0.0.1:8091 and run queries configured in an external module `StatsMetrics <https://github.com/brunopsoares/statsmetrics>`_.
+By default, it will bind to port 9420, query Couchbase on 127.0.0.1:8091 and run queries configured in an external module `StatsMetrics <https://github.com/brunopsoares/statsmetrics>`_.
 You can change these defaults as required by passing in options:
 
 .. code-block::
 
    $ prometheus-couchbase-exporter -c <couchbase host:port> -p <port to listen>
+
+
+Docker instructions:
+--------------------
+
+Environment variables
+In order to configure the Couchbase exporter for use with other than default settings you can pass in the
+following environment variables:
+
+.. csv-table:: Environment variables
+   :header: "Name", "Description", "Default value"
+   :widths: 18, 26, 10
+
+   "COUCHBASE_HOST", "Couchbase host address", "127.0.0.1"
+   "COUCHBASE_PORT", "Couchbase port address", "8091"
+   "COUCHBASE_USERNAME", "Couchbase username",
+   "COUCHBASE_PASSWORD", "Couchbase password",
+   "PROMETHEUS_PORT", "Prometheus port to listen", "9420"
+
+Running the container
+
+.. code-block::
+
+   docker run -t -i -p 9420:9420 -e COUCHBASE_HOST=127.0.0.1 -e COUCHBASE_PORT=8091 billmoritz/couchbase-exporter

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+set -e
+
+echo "Waiting for couchbase to be available at ${COUCHBASE_HOST}:${COUCHBASE_PORT}..."
+until curl -s -o /dev/null http://${COUCHBASE_HOST}:${COUCHBASE_PORT}/pools -u ${COUCHBASE_USERNAME}:${COUCHBASE_PASSWORD}
+do
+  echo "Waiting for couchbase to be available at ${COUCHBASE_HOST}:${COUCHBASE_PORT}..."
+  sleep 1
+done
+
+exec "$@"

--- a/prometheus_couchbase_exporter/__init__.py
+++ b/prometheus_couchbase_exporter/__init__.py
@@ -124,7 +124,7 @@ def parse_args():
         required=False,
         type=int,
         help='Listen to this port',
-        default=9119
+        default=9420
     )
     return parser.parse_args()
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open(path.join(path.abspath(path.dirname(__file__)), 'README.rst'), encodin
 setup(
     name='prometheus-couchbase-exporter',
 
-    version='1.0.3',
+    version='2.0.0',
 
     description='Couchbase query Prometheus exporter',
     long_description=long_description,


### PR DESCRIPTION
* Add Docker file, entry point script and documentation
* Bump version to 2.0.0 because of default behavior change
* Change default port to 9420 because 9119 is reserved for BIND. 
https://github.com/prometheus/prometheus/wiki/Default-port-allocations
I hope you don't mind that I took the liberty of adding this exporter to the official list. 